### PR TITLE
backends: add ssh tunnel backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This service can be used to control a Docker Engine from libswarm services. It t
 
 ### SSH tunnel
 
-*Help wanted!*
+*Johan Euphrosine (proppy)*
 
 ### Etcd
 

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -25,5 +25,6 @@ func New() *libswarm.Client {
 	backends.Bind("shipyard", Shipyard())
 	backends.Bind("ec2", Ec2())
 	backends.Bind("tutum", Tutum())
+	backends.Bind("tunnel", SSHTunnel())
 	return libswarm.AsClient(backends)
 }

--- a/backends/tunnel.go
+++ b/backends/tunnel.go
@@ -1,0 +1,119 @@
+//
+// Copyright (C) 2014 The Docker Cloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package backends
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"os/user"
+	"strings"
+
+	"code.google.com/p/go.crypto/ssh"
+	"github.com/docker/libswarm"
+)
+
+const (
+	usage      = "tunnel ip:port /path/to/ssh/key"
+	dockerHost = "127.0.0.1:4243"
+)
+
+// newSSHKey Read parses a private SSH key.
+func newSSHKey(path string) (ssh.Signer, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load ssh key from %q: %v", path, err)
+	}
+	defer f.Close()
+
+	bs, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ssh key: %v", err)
+	}
+	return ssh.ParsePrivateKey(bs)
+}
+
+// sshDialer is a ssh tunnel connection dialer.
+type sshDialer func(string, string) (net.Conn, error)
+
+// newSSHTunnel creates a SSH tunnel to a given IP and port.
+func newSSHTunnel(addr string, key ssh.Signer) (sshDialer, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %v", err)
+	}
+	conn, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		User: usr.Username,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(key),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial ssh conn to %q: %v", addr, err)
+	}
+	return func(net, addr string) (net.Conn, error) {
+		parts := strings.Split(addr, ":")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("no port to connect to %q: %v", addr, parts)
+		}
+		log.Printf("tunnel: tunneling connection to: %q", addr)
+		conn, err := conn.Dial("tcp", addr)
+		if err != nil {
+			log.Printf("tunnel: failed to connect to %q: %v", addr, err)
+		}
+		return conn, err
+	}, nil
+}
+
+func SSHTunnel() libswarm.Sender {
+	backend := libswarm.NewServer()
+	backend.OnSpawn(func(cmd ...string) (libswarm.Sender, error) {
+		if len(cmd) != 2 {
+			return nil, fmt.Errorf("tunnel: spawn takes exactly 2 arguments, got %d; usage: %s", len(cmd), usage)
+		}
+
+		addr, identityPath := cmd[0], cmd[1]
+		_, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("tunnel: invalid ssh connection string %q: %v", addr, err)
+		}
+		key, err := newSSHKey(identityPath)
+		if err != nil {
+			return nil, fmt.Errorf("tunnel: failed to get ssh key for identity %q: %v", identityPath, err)
+		}
+		log.Printf("tunnel: connecting to %q", addr)
+		dialer, err := newSSHTunnel(addr, key)
+		if err != nil {
+			return nil, fmt.Errorf("tunnel: failed to create ssh tunnel to %q: %v", addr, err)
+		}
+
+		log.Printf("tunnel: connected to %q", addr)
+		client := newClient()
+		client.urlHost = dockerHost
+		client.transport.Dial = dialer
+		b := &dockerClientBackend{
+			client: client,
+			Server: libswarm.NewServer(),
+		}
+		b.Server.OnAttach(b.attach)
+		b.Server.OnStart(b.start)
+		b.Server.OnLs(b.ls)
+		b.Server.OnSpawn(b.spawn)
+		return b.Server, nil
+	})
+	return backend
+}

--- a/backends/tunnel_test.go
+++ b/backends/tunnel_test.go
@@ -1,0 +1,93 @@
+package backends
+
+import (
+	"io/ioutil"
+	"log"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/docker/libswarm"
+
+	"code.google.com/p/go.crypto/ssh"
+)
+
+const (
+	testSSHListenAddr = "127.0.0.1:2022"
+	testSSHPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBALdGZxkXDAjsYk10ihwU6Id2KeILz1TAJuoq4tOgDWxEEGeTrcld
+r/ZwVaFzjWzxaf6zQIJbfaSEAhqD5yo72+sCAwEAAQJBAK8PEVU23Wj8mV0QjwcJ
+tZ4GcTUYQL7cF4+ezTCE9a1NrGnCP2RuQkHEKxuTVrxXt+6OF15/1/fuXnxKjmJC
+nxkCIQDaXvPPBi0c7vAxGwNY9726x01/dNbHCE0CBtcotobxpwIhANbbQbh3JHVW
+2haQh4fAG5mhesZKAGcxTyv4mQ7uMSQdAiAj+4dzMpJWdSzQ+qGHlHMIBvVHLkqB
+y2VdEyF7DPCZewIhAI7GOI/6LDIFOvtPo6Bj2nNmyQ1HU6k/LRtNIXi4c9NJAiAr
+rrxx26itVhJmcvoUhOjwuzSlP2bE5VHAvkGB352YBg==
+-----END RSA PRIVATE KEY-----
+`
+)
+
+func TestSSHTunnelSpawn(t *testing.T) {
+	chanchan := make(chan (<-chan ssh.NewChannel))
+	go func() {
+		config := &ssh.ServerConfig{
+			PublicKeyCallback: func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+				log.Println("discarding key based auth")
+				return nil, nil
+			},
+		}
+		listener, err := net.Listen("tcp", testSSHListenAddr)
+		if err != nil {
+			t.Fatalf("failed to listen on %q: %v", testSSHListenAddr, err)
+		}
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Fatalf("failed to accept incoming connect: %v", err)
+		}
+		log.Println("tunnel: test: new client")
+
+		key, err := ssh.ParsePrivateKey([]byte(testSSHPrivateKey))
+		if err != nil {
+			t.Fatalf("failed to parse host key")
+		}
+		config.AddHostKey(key)
+
+		_, chans, reqs, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			t.Fatalf("hanshaked failed: %v", err)
+		}
+		log.Println("tunnel: test: handshake succeeded")
+		go ssh.DiscardRequests(reqs)
+		chanchan <- chans
+	}()
+	tunnel := SSHTunnel()
+	tunnelClient := libswarm.AsClient(tunnel)
+	tmpKey, err := ioutil.TempFile("", "libswarm-tunnel-test-empty-key")
+	if err != nil {
+		t.Fatalf("failed to create temporary key: %v", err)
+	}
+	defer tmpKey.Close()
+	tmpKey.WriteString(testSSHPrivateKey)
+	dockerClient, err := tunnelClient.Spawn(testSSHListenAddr, tmpKey.Name())
+	if err != nil {
+		t.Fatalf("failed to spawn tunnel backend: %v", err)
+	}
+	go dockerClient.Ls()
+	chans := <-chanchan
+	newChan := <-chans
+	log.Printf("tunnel: test: got newchan:%q", newChan.ChannelType())
+	if newChan.ChannelType() != "direct-tcpip" {
+		t.Fatalf("expected tunneling with newchan:direct-tcpip, got %q", newChan.ChannelType())
+	}
+}
+
+func TestSSHTunnelSpawnBadArgs(t *testing.T) {
+	if _, err := libswarm.AsClient(SSHTunnel()).Spawn(); err == nil || !strings.Contains(err.Error(), "arguments") {
+		t.Fatalf("expected args error, got %q", err)
+	}
+	if _, err := libswarm.AsClient(SSHTunnel()).Spawn("bad-connection-string", ""); err == nil || !strings.Contains(err.Error(), "connection") {
+		t.Fatalf("expected connection error, got %q", err)
+	}
+	if _, err := libswarm.AsClient(SSHTunnel()).Spawn(testSSHListenAddr, "/unlikely-to-exists"); err == nil || !strings.Contains(err.Error(), "key") {
+		t.Fatalf("expected key error, got %q", err)
+	}
+}


### PR DESCRIPTION
This PR add a new SSH backend, that could be reused as a common base for cloud backend (gce, ec2, etc).
